### PR TITLE
Fix Flask-Migration issues.

### DIFF
--- a/foodapp/__init__.py
+++ b/foodapp/__init__.py
@@ -12,8 +12,8 @@ db=SQLAlchemy(app)
 migrate=Migrate(app, db)
 from foodapp.models import Order, Category, User, Meal, meals_orders_association
 
-with app.app_context():
-    db.create_all()
+# with app.app_context():
+#     db.create_all()
 
 from foodapp.views import *
 

--- a/foodapp/config.py
+++ b/foodapp/config.py
@@ -1,10 +1,5 @@
-import os
-
-current_path = os.path.dirname(os.path.realpath(__file__))
-db_path = "sqlite:///" + current_path + "\\fooddelivery.db"
-
 class Config:
     DEBUG = True
     SECRET_KEY= "secret_key"
-    SQLALCHEMY_DATABASE_URI = db_path
+    SQLALCHEMY_DATABASE_URI = r"sqlite:///foodapp/fooddelivery.db"
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/foodapp/views.py
+++ b/foodapp/views.py
@@ -126,20 +126,20 @@ def ordered():
     return render_template("ordered.html")
 
 
-res = requests.get('https://sheetdb.io/api/v1/459o1nx4znd0i')
-data = json.loads(res.text)
+# res = requests.get('https://sheetdb.io/api/v1/459o1nx4znd0i')
+# data = json.loads(res.text)
 # list_meals=json.loads(data.json)
 # print(list_meals)
 # with open('data.json', 'r', encoding='utf-8') as filejs:
 #     contents = json.load(filejs)
-with app.app_context():
-    for item in data:
-        meal = Meal(title=str(item['title']),
-                    price=int(item['price']),
-                    description=str(item['description']),
-                    picture=str(item['picture']),
-                    category_id=int(item['category_id']))
-        db.session.add(meal)
-    db.session.commit()
-
-print(db.session.query(Meal.id).all())
+# with app.app_context():
+#     for item in data:
+#         meal = Meal(title=str(item['title']),
+#                     price=int(item['price']),
+#                     description=str(item['description']),
+#                     picture=str(item['picture']),
+#                     category_id=int(item['category_id']))
+#         db.session.add(meal)
+#     db.session.commit()
+#
+# print(db.session.query(Meal.id).all())


### PR DESCRIPTION
Привет. 
Миграции не запускались потому что в процессе запуска кода были обращения (insert) в базу данных и попытка создать таблицы через `db.create_all()`
Так же путь к БД был указал не кросс платформенный, поправил и это.